### PR TITLE
Add spacing between blog articles and remove reordering

### DIFF
--- a/data/website.go
+++ b/data/website.go
@@ -67,11 +67,7 @@ func GetWebsiteData() Website {
 	}
 	data := response.(*WebsiteResponseData)
 
-	// Reverse the order of blog posts
 	posts := data.Blog.Posts
-	for i, j := 0, len(posts)-1; i < j; i, j = i+1, j-1 {
-		posts[i], posts[j] = posts[j], posts[i]
-	}
 
 	return Website{
 		Title:       data.Metadata.Title,

--- a/template/index.html
+++ b/template/index.html
@@ -2,10 +2,12 @@
 <p>{{.}}</p>
 {{ end }}
 <h3>Blog</h3>
-{{ range .Website.BlogPosts }} {{ .PubDate }} <br />
-<a href="{{$.Website.Url}}blog/{{ .Slug }}" target="_blank"
-  >{{ .Title }} - {{ .Summary }}</a
-><br />
+{{ range .Website.BlogPosts }} {{ .PubDate }}
+<br />
+<a href="{{$.Website.Url}}blog/{{ .Slug }}" target="_blank">
+{{ .Title }} - {{ .Summary }}</a>
+<br />
+<br />
 {{end}}
 <h3>Quote of the day :)</h3>
 <text


### PR DESCRIPTION
Introduce spacing between blog articles for improved readability and eliminate the previous functionality that reversed the order of blog posts.