### PR TITLE
Use flagcdn for currency flag images

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -32,8 +32,8 @@
     <td>
       <img
         alt="Canada Flag"
-        width="68"
-        src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d9/Flag_of_Canada_%28Pantone%29.svg/2880px-Flag_of_Canada_%28Pantone%29.svg.png"
+        width="66"
+        src="https://flagcdn.com/w80/ca.png"
       />
     </td>
     <td>CAD</td>
@@ -44,7 +44,7 @@
       <img
         alt="US Flag"
         width="66"
-        src="https://upload.wikimedia.org/wikipedia/en/thumb/a/a4/Flag_of_the_United_States.svg/1600px-Flag_of_the_United_States.svg.png?20151118161041"
+        src="https://flagcdn.com/w80/us.png"
       />
     </td>
     <td>USD</td>
@@ -55,7 +55,7 @@
       <img
         alt="Mexico Flag"
         width="66"
-        src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Flag_of_Mexico.svg/2560px-Flag_of_Mexico.svg.png"
+        src="https://flagcdn.com/w80/mx.png"
       />
     </td>
     <td>MXN</td>
@@ -66,7 +66,7 @@
       <img
         alt="Euro Flag"
         width="66"
-        src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b7/Flag_of_Europe.svg/2560px-Flag_of_Europe.svg.png"
+        src="https://flagcdn.com/w80/eu.png"
       />
     </td>
     <td>EUR</td>
@@ -77,7 +77,7 @@
       <img
         alt="UK Flag"
         width="66"
-        src="https://upload.wikimedia.org/wikipedia/en/thumb/a/ae/Flag_of_the_United_Kingdom.svg/1920px-Flag_of_the_United_Kingdom.svg.png"
+        src="https://flagcdn.com/w80/gb.png"
       />
     </td>
     <td>GBP</td>
@@ -88,7 +88,7 @@
       <img
         alt="Australia Flag"
         width="66"
-        src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/88/Flag_of_Australia_%28converted%29.svg/2560px-Flag_of_Australia_%28converted%29.svg.png"
+        src="https://flagcdn.com/w80/au.png"
       />
     </td>
     <td>AUD</td>
@@ -99,7 +99,7 @@
       <img
         alt="Japan Flag"
         width="66"
-        src="https://upload.wikimedia.org/wikipedia/en/thumb/9/9e/Flag_of_Japan.svg/1920px-Flag_of_Japan.svg.png"
+        src="https://flagcdn.com/w80/jp.png"
       />
     </td>
     <td>JPY</td>


### PR DESCRIPTION
## Problem

The currency flag images in the README were hot-linked from `upload.wikimedia.org` and rendering as broken. Wikimedia throttles/blocks hot-linking, and GitHub's Camo image proxy often can't fetch those URLs.

## Change

Switch all seven flags (CAD, USD, MXN, EUR, GBP, AUD, JPY) to [flagcdn.com](https://flagcdn.com) — a CDN built for hot-linking, with stable, proxy-friendly URLs:

```html
``&lt;img alt="Canada Flag" width="66" src="https://flagcdn.com/w80/ca.png" /&gt;``
```

Also normalized the Canada flag's `width` from `68` to `66` to match the rest of the table.

## Verification

- No `wikimedia` / `wikipedia` references remain in `template/index.html`
- `go run main.go` renders the template cleanly (exits `0`)

## Note

Follow-up to #26 (already merged) — that PR removed the weather code and bumped deprecated Actions; this commit landed on the branch just after #26 merged, so it needs its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMzsTG5qcD8hP4cGvdcU3K

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMzsTG5qcD8hP4cGvdcU3K)_